### PR TITLE
use liquid templates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    llm_eval_ruby (0.2.0)
+    llm_eval_ruby (0.2.1)
       httparty (~> 0.22.0)
+      liquid (~> 5.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -17,6 +18,7 @@ GEM
       multi_xml (>= 0.5.2)
     json (2.7.5)
     language_server-protocol (3.17.0.3)
+    liquid (5.5.1)
     mini_mime (1.1.5)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)

--- a/lib/llm_eval_ruby/prompt_adapters/base.rb
+++ b/lib/llm_eval_ruby/prompt_adapters/base.rb
@@ -14,7 +14,8 @@ module LlmEvalRuby
         end
 
         def compile(prompt:, variables:)
-          raise NotImplementedError
+          compiled = render_template(prompt.content, variables)
+          LlmEvalRuby::PromptTypes::Compiled.new(adapter: self, role: prompt.role, content: compiled)
         end
 
         private
@@ -38,6 +39,11 @@ module LlmEvalRuby
               raise "Unsupported role #{prompt["role"]}"
             end
           end
+        end
+
+        def render_template(template, variables)
+          template = Liquid::Template.parse(template)
+          template.render(variables.stringify_keys)
         end
       end
     end

--- a/lib/llm_eval_ruby/prompt_adapters/langfuse.rb
+++ b/lib/llm_eval_ruby/prompt_adapters/langfuse.rb
@@ -12,20 +12,10 @@ module LlmEvalRuby
           handle_response(response)
         end
 
-        def compile(prompt:, variables:)
-          compiled = format(convert_prompt(prompt.content), variables)
-          LlmEvalRuby::PromptTypes::Compiled.new(adapter: self, role: prompt.role, content: compiled)
-        end
-
         private
 
         def client
           @client ||= ApiClients::Langfuse.new(**LlmEvalRuby.config.langfuse_options)
-        end
-
-        # convert {{variable}} to %<variable>s
-        def convert_prompt(prompt)
-          prompt.gsub(/\{\{([^}]+)\}\}/, '%<\1>s')
         end
       end
     end

--- a/lib/llm_eval_ruby/prompt_adapters/local.rb
+++ b/lib/llm_eval_ruby/prompt_adapters/local.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "liquid"
 require_relative "base"
 
 module LlmEvalRuby
@@ -18,18 +19,6 @@ module LlmEvalRuby
           end
 
           handle_response(system_prompts + user_prompt)
-        end
-
-        def compile(prompt:, variables:)
-          compiled = format(convert_prompt(prompt.content), variables)
-          LlmEvalRuby::PromptTypes::Compiled.new(adapter: self, role: prompt.role, content: compiled)
-        end
-
-        private
-
-        # convert {{variable}} to %<variable>s
-        def convert_prompt(prompt)
-          prompt.gsub(/\{\{([^}]+)\}\}/, '%<\1>s')
         end
       end
     end

--- a/lib/llm_eval_ruby/version.rb
+++ b/lib/llm_eval_ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LlmEvalRuby
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/llm_eval_ruby.gemspec
+++ b/llm_eval_ruby.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
   spec.add_dependency "httparty", "~> 0.22.0"
+  spec.add_dependency "liquid", "~> 5.5.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/llm_eval_ruby_spec.rb
+++ b/spec/llm_eval_ruby_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe LlmEvalRuby do
   it "has a version number" do
-    expect(LlmEvalRuby::VERSION).to be("0.2.0")
+    expect(LlmEvalRuby::VERSION).to be("0.2.1")
   end
 end


### PR DESCRIPTION
This PR allows to store prompts as a liquid template.
Liquid has iterators and allows to store if else logic inside the prompt.

An example of usage for refine test case prompt:
```
"Goal of the test:
'''
{{goal}}
'''

Out of scope:
'''
{{out_of_scope}}
'''

Additional requirements:
'''
{{additional_requirements}}
'''

Feature Description:
'''
{{test_features}}
'''

Original Gherkin Test Case to refine:
'''
{{test_case_content}}
'''

{% if compared_screenshots_message %}
Difference between the last two screenshots:
'''
{{compared_screenshots_message}}
'''
{% endif %}

{% if html_diff_message %}
Changes in HTML after the last test case step:

{{html_diff_message}}
{% endif %}

{% if passed_parents %}
Chain of previous versions of the test case:
{% for test_case in passed_parents %}
'''
{{ test_case }}
'''
{% endfor %}
{% endif %}

{% if passed_relatives %}
Other test cases already executed, please avoid generation of the same test cases:
{% for test_case in passed_relatives %}
'''
{{ test_case }}
'''
{% endfor %}
{% endif %}
```