### PR TITLE
fix span and generation for local adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,7 @@
 ## [0.2.5] - 2024-12-16
 
 - Added metadata field to traces.
+
+## [0.2.6] - 2025-03-07
+
+- Fixed span for local adapter.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    llm_eval_ruby (0.2.5)
+    llm_eval_ruby (0.2.6)
       httparty (~> 0.22.0)
       liquid (~> 5.5.0)
 

--- a/lib/llm_eval_ruby/trace_adapters/local.rb
+++ b/lib/llm_eval_ruby/trace_adapters/local.rb
@@ -21,7 +21,7 @@ module LlmEvalRuby
 
           return span unless block_given?
 
-          result = yield
+          result = yield span
 
           end_span(span, result)
 
@@ -43,7 +43,7 @@ module LlmEvalRuby
 
           return generation unless block_given?
 
-          result = yield
+          result = yield generation
 
           end_generation(generation, result)
 

--- a/lib/llm_eval_ruby/version.rb
+++ b/lib/llm_eval_ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LlmEvalRuby
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end

--- a/spec/llm_eval_ruby_spec.rb
+++ b/spec/llm_eval_ruby_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe LlmEvalRuby do
   it "has a version number" do
-    expect(LlmEvalRuby::VERSION).to be("0.2.5")
+    expect(LlmEvalRuby::VERSION).to be("0.2.6")
   end
 end


### PR DESCRIPTION
Fixes:
`NoMethodError (undefined method `metadata=' for class LlmEvalRuby::TraceAdapters::Local):`